### PR TITLE
Add support and tests for loading tilesets from external .tsx files.

### DIFF
--- a/lib/tmx.rb
+++ b/lib/tmx.rb
@@ -17,7 +17,9 @@ module Tmx
   #
   def load(filename,options={})
     options = default_options(filename).merge(options)
-    parse contents(filename), options
+
+    # Pass :filename in options for resolving relative "source" paths
+    parse contents(filename), options.merge(:filename => filename)
   end
 
   #

--- a/lib/tmx/parsers/tmx.rb
+++ b/lib/tmx/parsers/tmx.rb
@@ -120,10 +120,23 @@ module Tmx
 
       def map_tilesets(xml)
         xml.xpath("map/tileset").map do |tileset|
+          # Firstgid is usually set in the main file,
+          # even if a tileset is read from a separate file.
+          firstgid = tileset.xpath("@firstgid").text.to_i
+
+          source = tileset.xpath("@source")
+          if source && source.size > 0
+            this_dir = @options[:filename] ? File.dirname(@options[:filename]) : "."
+            tileset_path = File.join(this_dir, source.text)
+            contents = File.read(tileset_path)
+            results = Nokogiri::XML(contents)
+            tileset = results.xpath("tileset")
+          end
+
           image = tileset.xpath("image")
 
           properties = {
-            "firstgid" => tileset.xpath("@firstgid").text.to_i,
+            "firstgid" => firstgid || tileset.xpath("@firstgid").text.to_i,
             "name" => tileset.xpath("@name").text,
             "tilewidth" => tileset.xpath("@tilewidth").text.to_i,
             "tileheight" => tileset.xpath("@tileheight").text.to_i,

--- a/spec/features/xml_source_tileset_spec.rb
+++ b/spec/features/xml_source_tileset_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+describe Tmx, "Map with Source Tileset" do
+
+  let(:fixture_file) { File.join File.dirname(__FILE__), "..", "fixtures", "map-source-tileset.tmx" }
+
+  let(:map) do
+    described_class.load(fixture_file)
+  end
+
+  let(:subject) { map }
+
+  its(:width) { should eq 10 }
+  its(:height) { should eq 20 }
+  its(:tilewidth) { should eq 32 }
+  its(:tileheight) { should eq 32 }
+
+  describe '#layers' do
+    it "has the correct number of layers" do
+      expect(subject.layers).to have(1).item
+    end
+  end
+
+  describe '#tilesets' do
+    it "has the correct number of tilesets" do
+      expect(subject.tilesets).to have(1).item
+    end
+
+    context "when evaluating the first tileset" do
+      let(:subject) { map.tilesets.first }
+
+      its(:firstgid) { should eq 1 }
+      its(:image) { should eq "tiles.png" }
+      its(:imageheight) { should eq 400 }
+      its(:imagewidth) { should eq 640 }
+      its(:margin) { should eq 0 }
+      its(:spacing) { should eq 2 }
+      its(:tileheight) { should eq 32 }
+      its(:tilewidth) { should eq 32 }
+      its(:properties) { should eq({}) }
+    end
+  end
+
+
+end

--- a/spec/fixtures/map-source-tileset.tmx
+++ b/spec/fixtures/map-source-tileset.tmx
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.0" orientation="orthogonal" width="10" height="20" tilewidth="32" tileheight="32">
+ <tileset firstgid="1" source="tileset.tsx"> </tileset>
+ <layer name="Tile Layer 1" width="10" height="20">
+  <data encoding="base64" compression="zlib">
+   eJxjZmBgYIZiRjTMhISZR9WNqhuB6gBbPgF9
+  </data>
+ </layer>
+</map>

--- a/spec/fixtures/tileset.tsx
+++ b/spec/fixtures/tileset.tsx
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tileset name="terrain" tilewidth="32" tileheight="32" spacing="2">
+  <image source="tiles.png" width="640" height="400"/>
+</tileset


### PR DESCRIPTION
This allows tilesets to be loaded from external .tsx files.  I was using this to look at files from SourceOfTales, though I'm sure they're not the only user of .tsx files in the wild.

I included tests :-)
