### PR TITLE
Treat 0 as false for 'visible' properties.

### DIFF
--- a/lib/tmx/parsers/tmx.rb
+++ b/lib/tmx/parsers/tmx.rb
@@ -149,6 +149,8 @@ module Tmx
             "image" => image.xpath("@source").text,
             "imageheight" => image.xpath("@height").text.to_i,
             "imagewidth" => image.xpath("@width").text.to_i,
+            # "imagetrans" is a color to treat as transparent, like "ff00ff" for magenta.
+            "imagetrans" => image.xpath("@trans").text,
             "properties" => properties(xml)
           }
         end


### PR DESCRIPTION
I'm using TMX files from SourceOfTales which have "visible=0" for layers to indicate invisible ones.  I didn't want to mess up existing "false" stuff, so I added a private method to treat either 0 or "false" as false.  Existing tests pass.
