### PR TITLE
Add basic parsing for image transparency.

### DIFF
--- a/lib/tmx/parsers/tmx.rb
+++ b/lib/tmx/parsers/tmx.rb
@@ -145,6 +145,8 @@ module Tmx
             "image" => image.xpath("@source").text,
             "imageheight" => image.xpath("@height").text.to_i,
             "imagewidth" => image.xpath("@width").text.to_i,
+            # "imagetrans" is a color to treat as transparent, like "ff00ff" for magenta.
+            "imagetrans" => image.xpath("@trans").text,
             "properties" => properties(xml)
           }
         end


### PR DESCRIPTION
Add "trans" property for images, example value "ff00ff", which is used to indicate a transparent color for them.
