### PR TITLE
Update tmx.rb

### DIFF
--- a/lib/tmx/parsers/tmx.rb
+++ b/lib/tmx/parsers/tmx.rb
@@ -72,6 +72,7 @@ module Tmx
           layer_hash["y"] = layer.xpath("@y").text.to_i
 
           layer_hash["data"] = data_from_layer(layer)
+          layer_hash["properties"] = properties(layer)
 
           layers.push layer_hash
         end


### PR DESCRIPTION
'properties' is not being read from 'Layer' elements, but its specified in TMX specs. This commit fixes that.
