### PR TITLE
Don't sort layers by name; add back types to imagelayers and objectgroups

### DIFF
--- a/lib/tmx/map.rb
+++ b/lib/tmx/map.rb
@@ -38,7 +38,6 @@ module Tmx
       object_groups = hash.delete(:object_groups)
       hash[:layers] += image_layers
       hash[:layers] += object_groups
-      hash[:layers].sort_by! { |l| l[:name] }
       hash.delete(:contents)
 
       object_groups.each do |object_layer|

--- a/lib/tmx/map.rb
+++ b/lib/tmx/map.rb
@@ -35,7 +35,9 @@ module Tmx
 
       # Need to add back all non-tilelayers to hash["layers"]
       image_layers = hash.delete(:image_layers)
+      image_layers.map { |i| i[:type] = "imagelayer" }
       object_groups = hash.delete(:object_groups)
+      object_groups.map { |g| g[:type] = "objectgroup" }
       hash[:layers] += image_layers
       hash[:layers] += object_groups
       hash.delete(:contents)


### PR DESCRIPTION
My previous branch had several bugs, one of which was severe. This fixes that. I won't be shocked if this isn't the only bug I've left. And I know there are some more recent changes to the TMX JSON format that neither you nor I have updated for. But this fixes my most recent problems with it.